### PR TITLE
reattach-to-user-namespace no longer needed

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -4,6 +4,7 @@ set -g history-limit 100000
 # use VI
 set-window-option -g mode-keys vi
 unbind -t vi-copy Enter
+bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"
 
 # Use ctrl-e instead of ctrl-b
 set -g prefix C-e


### PR DESCRIPTION
Removes error messages with OSX 10.10
