### PR TITLE
Adds rubocop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -13,6 +13,12 @@ AllCops:
 
 # Rules
 # Whitespace / Indentation
+Style/AlignArray:
+  StyleGuide: "https://github.com/crowdtap/ruby#indentation"
+
+Style/AlignHash:
+  StyleGuide: "https://github.com/crowdtap/ruby#indentation"
+
 Style/AlignParameters:
   EnforcedStyle: with_first_parameter
   StyleGuide: "https://github.com/crowdtap/ruby#indentation"
@@ -100,3 +106,51 @@ Style/MethodCallParentheses:
 
 Style/SpaceAfterMethodName:
   StyleGuide: "https://github.com/crowdtap/ruby#method-calls"
+
+# Conditional Expressions / Keywords
+Style/AndOr:
+  StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
+
+Style/IfUnlessModifier:
+  StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
+
+Style/IfUnlessModifierOfIfUnless:
+  StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
+
+Style/MultilineIfThen:
+  StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
+
+Style/MultilineTernaryOperator:
+  StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
+
+Style/ParenthesesAroundCondition:
+  StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
+
+Style/UnlessElse:
+  StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
+
+# Conditional Expressions / Ternary Operator
+Style/MultilineTernaryOperator:
+  StyleGuide: "https://github.com/crowdtap/ruby#ternary-operator"
+
+Style/OneLineConditional:
+  StyleGuide: "https://github.com/crowdtap/ruby#ternary-operator"
+
+# Syntax
+Lint/UnusedBlockArgument:
+  StyleGuide: "https://github.com/crowdtap/ruby#syntax"
+
+Lint/UnusedMethodArgument:
+  StyleGuide: "https://github.com/crowdtap/ruby#syntax"
+
+Style/BlockDelimiters:
+  StyleGuide: "https://github.com/crowdtap/ruby#syntax"
+
+Style/For:
+  StyleGuide: "https://github.com/crowdtap/ruby#syntax"
+
+Style/RedundantReturn:
+  StyleGuide: "https://github.com/crowdtap/ruby#syntax"
+
+Style/RedundantSelf:
+  StyleGuide: "https://github.com/crowdtap/ruby#syntax"

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,19 +1,77 @@
 # Common configuration
 AllCops:
   Include:
-    - Rakefile
-    - config.ru
+    - '**/config.ru'
+    - '**/Gemfile'
+    - '**/Rakefile'
   Exclude:
-    - db/**
-    - config/**
-    - script/**
-    - vendor/**
+    - 'db/**'
+    - 'config/**'
+    - 'script/**'
+    - 'vendor/**'
   DisabledByDefault: true
-  DisplayCopNames: true
-  Rails:
-    Enabled: true
 
 # Rules
-# Whitespace
+# Whitespace / Indentation
+Style/AlignParameters:
+  EnforcedStyle: with_first_parameter
+  StyleGuide: "https://github.com/crowdtap/ruby#indentation"
+
+Style/CaseIndentation:
+  IndentWhenRelativeTo: case
+  StyleGuide: "https://github.com/crowdtap/ruby#indentation"
+
+Style/IndentationWidth:
+  Width: 2
+  StyleGuide: "https://github.com/crowdtap/ruby#indentation"
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+  StyleGuide: "https://github.com/crowdtap/ruby#indentation"
+
+Style/Tab:
+  StyleGuide: "https://github.com/crowdtap/ruby#indentation"
+
+# Whitespace / Inline
+Style/SpaceAroundBlockParameters:
+  EnforcedStyleInsidePipes: no_space
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
+Style/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
+Style/SpaceAroundOperators:
+  AllowForAlignment: true
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
+Style/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
+Style/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  SpaceBeforeBlockParameters: true
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
+Style/SpaceInsideBrackets:
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
+Style/SpaceInsideParens:
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
+Style/TrailingBlankLines:
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
 Style/TrailingWhitespace:
   StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
+# Whitespace / Newlines
+Style/MultilineBlockLayout:
+  StyleGuide: "https://github.com/crowdtap/ruby#newlines"

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -33,6 +33,10 @@ Style/Tab:
   StyleGuide: "https://github.com/crowdtap/ruby#indentation"
 
 # Whitespace / Inline
+Style/DotPosition:
+  EnforcedStyle: leading
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"
+
 Style/SpaceAroundBlockParameters:
   EnforcedStyleInsidePipes: no_space
   StyleGuide: "https://github.com/crowdtap/ruby#inline"
@@ -75,3 +79,24 @@ Style/TrailingWhitespace:
 # Whitespace / Newlines
 Style/MultilineBlockLayout:
   StyleGuide: "https://github.com/crowdtap/ruby#newlines"
+
+Style/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
+  StyleGuide: "https://github.com/crowdtap/ruby#newlines"
+
+# Line length
+Metrics/LineLength:
+  Max: 100
+  StyleGuide: "https://github.com/crowdtap/ruby#line-length"
+
+# Methods / Definitions
+Style/MethodDefParentheses:
+  EnforcedStyle: require_parentheses
+  StyleGuide: "https://github.com/crowdtap/ruby#method-definitions"
+
+# Methods / Calls
+Style/MethodCallParentheses:
+  StyleGuide: "https://github.com/crowdtap/ruby#method-calls"
+
+Style/SpaceAfterMethodName:
+  StyleGuide: "https://github.com/crowdtap/ruby#method-calls"

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - 'vendor/**'
   DisabledByDefault: true
 
-# Rules
+# Styles
 # Whitespace / Indentation
 Style/AlignArray:
   StyleGuide: "https://github.com/crowdtap/ruby#indentation"
@@ -114,13 +114,13 @@ Style/AndOr:
 Style/IfUnlessModifier:
   StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
 
-Style/IfUnlessModifierOfIfUnless:
-  StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
-
 Style/MultilineIfThen:
   StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
 
 Style/MultilineTernaryOperator:
+  StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
+
+Style/Not:
   StyleGuide: "https://github.com/crowdtap/ruby#conditional-keywords"
 
 Style/ParenthesesAroundCondition:
@@ -154,3 +154,321 @@ Style/RedundantReturn:
 
 Style/RedundantSelf:
   StyleGuide: "https://github.com/crowdtap/ruby#syntax"
+
+# Naming
+Lint/UnderscorePrefixedVariableName:
+  StyleGuide: "https://github.com/crowdtap/ruby#naming"
+
+Style/ClassAndModuleCamelCase:
+  StyleGuide: "https://github.com/crowdtap/ruby#naming"
+
+Style/ConstantName:
+  StyleGuide: "https://github.com/crowdtap/ruby#naming"
+
+Style/MethodName:
+  EnforcedStyle: snake_case
+  StyleGuide: "https://github.com/crowdtap/ruby#naming"
+
+Style/VariableName:
+  EnforcedStyle: snake_case
+  StyleGuide: "https://github.com/crowdtap/ruby#naming"
+
+# Classes
+Style/AccessModifierIndentation:
+  EnforcedStyle: indent
+  StyleGuide: "https://github.com/crowdtap/ruby#naming"
+
+Style/ClassVars:
+  StyleGuide: "https://github.com/crowdtap/ruby#classes"
+
+Style/IndentationConsistency:
+  StyleGuide: "https://github.com/crowdtap/ruby#classes"
+
+# Exceptions
+Lint/HandleExceptions:
+  StyleGuide: "https://github.com/crowdtap/ruby#exceptions"
+
+Lint/RescueException:
+  StyleGuide: "https://github.com/crowdtap/ruby#exceptions"
+
+# Collections
+Style/CollectionMethods:
+  PreferredMethods:
+    collect!: 'map!'
+    collect: 'map'
+    count: 'size'
+    find: 'detect'
+    find_all: 'select'
+    inject: 'reduce'
+    length: 'size'
+  StyleGuide: "https://github.com/crowdtap/ruby#collections"
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+  StyleGuide: "https://github.com/crowdtap/ruby#collections"
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+  StyleGuide: "https://github.com/crowdtap/ruby#collections"
+
+Style/MultilineHashBraceLayout:
+  StyleGuide: "https://github.com/crowdtap/ruby#collections"
+
+# Rails
+Rails/ActionFilter:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/Date:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/Delegate:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/FindBy:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/FindEach:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/HasAndBelongsToMany:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/Output:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/PluralizationGrammar:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/ReadWriteAttribute:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/ScopeArgs:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/TimeZone:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+Rails/Validation:
+  StyleGuide: "https://github.com/crowdtap/ruby#rails"
+
+# Additional Metrics
+Metrics/AbcSize:
+  Enabled: true
+
+Metrics/BlockNesting:
+  Enabled: true
+
+Metrics/CyclomaticComplexity:
+  Enabled: true
+
+Metrics/PerceivedComplexity:
+  Enabled: true
+
+# Additional Lint
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/AssignmentInCondition:
+  Enabled: true
+
+Lint/BlockAlignment:
+  Enabled: true
+
+Lint/CircularArgumentReference:
+  Enabled: true
+
+Lint/ConditionPosition:
+  Enabled: true
+
+Lint/Debugger:
+  Enabled: true
+
+Lint/DefEndAlignment:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Lint/DuplicateMethods:
+  Enabled: true
+
+Lint/DuplicatedKey:
+  Enabled: true
+
+Lint/EachWithObjectArgument:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EmptyEnsure:
+  Enabled: true
+
+Lint/EmptyInterpolation:
+  Enabled: true
+
+Lint/EndAlignment:
+  Enabled: true
+
+Lint/EndInMethod:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/Eval:
+  Enabled: true
+
+Lint/FloatOutOfRange:
+  Enabled: true
+
+Lint/FormatParameterMismatch:
+  Enabled: true
+
+Lint/HandleExceptions:
+  Enabled: true
+
+Lint/ImplicitStringConcatenation:
+  Enabled: true
+
+Lint/IneffectiveAccessModifier:
+  Enabled: true
+
+Lint/InvalidCharacterLiteral:
+  Enabled: true
+
+Lint/LiteralInCondition:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Lint/Loop:
+  Enabled: true
+
+Lint/NestedMethodDefinition:
+  Enabled: true
+
+Lint/NextWithoutAccumulator:
+  Enabled: true
+
+Lint/NonLocalExitFromIterator:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
+Lint/RandOne:
+  Enabled: true
+
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RescueException:
+  Enabled: true
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
+Lint/StringConversionInInterpolation:
+  Enabled: true
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+
+Lint/UnneededDisable:
+  Enabled: true
+
+Lint/UnusedBlockArgument:
+  Enabled: true
+
+Lint/UnusedMethodArgument:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UselessAccessModifier:
+  Enabled: true
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Lint/UselessComparison:
+  Enabled: true
+
+Lint/UselessElseWithoutRescue:
+  Enabled: true
+
+Lint/UselessSetterCall:
+  Enabled: true
+
+Lint/Void:
+  Enabled: true
+
+# Additional Performance
+Performance/Casecmp:
+  Enabled: true
+
+Performance/CaseWhenSplat:
+  Enabled: true
+
+Performance/Count:
+  Enabled: true
+
+Performance/Detect:
+  Enabled: true
+
+Performance/DoubleStartEndWith:
+  Enabled: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/FixedSize:
+  Enabled: true
+
+Performance/FlatMap:
+  Enabled: true
+
+Performance/HashEachMethods:
+  Enabled: true
+
+Performance/LstripRstrip:
+  Enabled: true
+
+Performance/RangeInclude:
+  Enabled: true
+
+Performance/RedundantBlockCall:
+  Enabled: true
+
+Performance/RedundantMatch:
+  Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true
+
+Performance/RedundantSortBy:
+  Enabled: true
+
+Performance/ReverseEach:
+  Enabled: true
+
+Performance/Sample:
+  Enabled: true
+
+Performance/Size:
+  Enabled: true
+
+Performance/StartWith:
+  Enabled: true
+
+Performance/StringReplacement:
+  Enabled: true
+
+Performance/TimesMap:
+  Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -252,9 +252,6 @@ Rails/Validation:
   StyleGuide: "https://github.com/crowdtap/ruby#rails"
 
 # Additional Metrics
-Metrics/AbcSize:
-  Enabled: true
-
 Metrics/BlockNesting:
   Enabled: true
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,0 +1,19 @@
+# Common configuration
+AllCops:
+  Include:
+    - Rakefile
+    - config.ru
+  Exclude:
+    - db/**
+    - config/**
+    - script/**
+    - vendor/**
+  DisabledByDefault: true
+  DisplayCopNames: true
+  Rails:
+    Enabled: true
+
+# Rules
+# Whitespace
+Style/TrailingWhitespace:
+  StyleGuide: "https://github.com/crowdtap/ruby#inline"

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -5,10 +5,10 @@ AllCops:
     - '**/Gemfile'
     - '**/Rakefile'
   Exclude:
-    - 'db/**'
-    - 'config/**'
-    - 'script/**'
-    - 'vendor/**'
+    - 'db/**/*'
+    - 'config/**/*'
+    - 'script/**/*'
+    - 'vendor/**/*'
   DisabledByDefault: true
 
 # Styles
@@ -92,7 +92,7 @@ Style/EmptyLineBetweenDefs:
 
 # Line length
 Metrics/LineLength:
-  Max: 100
+  Max: 150
   StyleGuide: "https://github.com/crowdtap/ruby#line-length"
 
 # Methods / Definitions

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 # Installs our dotfiles
 #
 
-declare -a dotfiles=(ackrc tmux tmux.conf vim vimrc gvimrc gemrc irb irbrc.d jshintrc rdebugrc rvmrc zprezto zlogin zlogout zpreztorc zprofile zshenv zshrc zsh-themes gitconfig-ct editrc ops)
+declare -a dotfiles=(ackrc tmux tmux.conf vim vimrc gvimrc gemrc irb irbrc.d jshintrc rdebugrc rvmrc zprezto zlogin zlogout zpreztorc zprofile zshenv zshrc zsh-themes gitconfig-ct editrc ops rubocop.yml)
 
 if [ ! -d 'zprezto' ]; then
   echo "Installing zprezto..."

--- a/vimrc
+++ b/vimrc
@@ -252,6 +252,7 @@ let g:syntastic_enable_signs = 1
 let g:syntastic_mode_map = { 'mode': 'active',
                            \ 'active_filetypes': [],
                            \ 'passive_filetypes': ['c', 'scss', 'html', 'scala'] }
+let g:syntastic_ruby_checkers = ['rubocop']
 let g:syntastic_javascript_checkers = ['jshint']
 
 let g:quickfixsigns_classes=['qfl', 'vcsdiff', 'breakpoints']


### PR DESCRIPTION
Style checks based on our style guide
https://github.com/crowdtap/ruby

Added other performance / lint rules from rubocop default
https://raw.githubusercontent.com/bbatsov/rubocop/v0.40.0/config/enabled.yml

example syntastic integration
![image](https://cloud.githubusercontent.com/assets/6531644/16055389/0e1f3d96-323f-11e6-88a3-e7d6a4bdaa7d.png)


Code climate, if we use it, uses rubocop 0.37, but the syntax is the same (this config runs fine there as well) (if you have access to this, it will take a while to load)
https://codeclimate.com/repos/575f027f86e1cf007c001197/compare/ch-code-climate