### PR TITLE
Enable mouse for copy-mode and scroll inside tmux pane

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -58,10 +58,9 @@ set-window-option -g window-status-current-bg yellow
 set-window-option -g window-status-current-fg black
 set-option -g renumber-windows on
 
-set -g mouse-select-pane off
-set -g mouse-select-window off
-set -g mouse-resize-pane off
-set -g mode-mouse off
+set -g mouse on
+bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
+bind -n WheelDownPane select-pane -t= \; send-keys -M
 
 # Pane mappings (Will work with Mac only if option key is meta, see readme)
 


### PR DESCRIPTION
Scrolling with the mouse won't scroll the terminal window anymore, only the tmux pane.
This will also enable us to enter copy-mode by just scrolling. Selecting with the mouse will have the same effect as if you were selecting in copy mode. 

**Example**
![example](http://g.recordit.co/mOOuZU0i9H.gif)

**Big advantage** comes in play when using split panels
![advantage](http://g.recordit.co/lQRn2OoHye.gif)

Known Gotcha: When selecting with the mouse, as soon as you release the mouse button, the selection will be lost. In order to copy before losing the selection, click `Enter` or `y` while still holding the mouse button. If you want to use ITerm selection, hold `Option` while selecting with the mouse.
