### PR TITLE
Explicitly sets rubocop path

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -253,6 +253,7 @@ let g:syntastic_mode_map = { 'mode': 'active',
                            \ 'active_filetypes': [],
                            \ 'passive_filetypes': ['c', 'scss', 'html', 'scala'] }
 let g:syntastic_ruby_checkers = ['rubocop']
+let g:syntastic_ruby_rubocop_exec = '/opt/boxen/rbenv/shims/rubocop'
 let g:syntastic_javascript_checkers = ['jshint']
 
 let g:quickfixsigns_classes=['qfl', 'vcsdiff', 'breakpoints']


### PR DESCRIPTION
For a few people, they haven't been able to get rubocop working without explicitly specifying the executable path

This shouldn't be harmful since it's just going to use the version we added to boxen

```
[~/code/dotfiles]$ /opt/boxen/rbenv/shims/rubocop -v
0.40.0
```
